### PR TITLE
Implement complete LoViT features

### DIFF
--- a/content/LoViT_APTOS/datasets.py
+++ b/content/LoViT_APTOS/datasets.py
@@ -6,6 +6,25 @@ import torch
 from torch.utils.data import Dataset, DataLoader
 from torchvision.transforms import Compose, Resize, ToTensor, Normalize
 from decord import VideoReader, cpu
+import numpy as np
+
+SIGMA_L = 3   # 左側 3σ_l
+SIGMA_R = 12  # 右側 3σ_r
+
+def build_phase_heat(gt_intervals, total_frames):
+    """
+    gt_intervals: [(start_f, end_f, phase_id), ...] ※フレーム index
+    total_frames: int
+    return h: (total_frames,)  float32
+    """
+    h = np.zeros(total_frames, np.float32)
+    for s, e, _ in gt_intervals[:-1]:
+        bp = e                       # フェーズ切替点を終端フレームに置く
+        for t in range(max(0, bp-3*SIGMA_L), bp):
+            h[t] = np.exp(-((t-bp)**2)/(2*(SIGMA_L**2)))
+        for t in range(bp, min(total_frames, bp+3*SIGMA_R)):
+            h[t] = np.exp(-((t-bp)**2)/(2*(SIGMA_R**2)))
+    return h
 
 MEAN = [0.485, 0.456, 0.406]
 STD  = [0.229, 0.224, 0.225]
@@ -44,11 +63,19 @@ class PhaseVideoDataset(Dataset):
         self.alpha = alpha
         self.every_sec = every_sec
         self.samples = []  # (video, sec, phase_id)
+        self.heat_map = {}
+        self.intervals = {}
         for v, rows in self.anno.groupby('video_id'):
             fps = self.fps_tbl[f'{v}.mp4']
+            ivs = []
             for _, r in rows.iterrows():
                 idxs = _sample_indices(fps, r.start, r.end, every_sec)
                 self.samples += [(v, s/fps, r.phase_id) for s in idxs]
+                ivs.append((int(round(r.start*fps)), int(round(r.end*fps)), r.phase_id))
+            vr = VideoReader(str(self.video_root/f'{v}.mp4'), ctx=cpu(0))
+            total_frames = len(vr)
+            self.intervals[v] = ivs
+            self.heat_map[v] = build_phase_heat(ivs, total_frames)
 
     def __len__(self):  return len(self.samples)
 
@@ -61,4 +88,5 @@ class PhaseVideoDataset(Dataset):
         w = max(1, frame_idx // self.alpha)
         idxs = [max(0, frame_idx - w*(self.alpha-1-i)) for i in range(self.alpha)]
         clip = torch.stack([_basic_tf(vr[i].asnumpy()) for i in idxs])  # (α,3,H,W)
-        return clip, pid
+        ht = torch.tensor(self.heat_map[vid][frame_idx], dtype=torch.float32)
+        return clip, pid, ht

--- a/content/LoViT_APTOS/ginformer.py
+++ b/content/LoViT_APTOS/ginformer.py
@@ -1,9 +1,52 @@
 import torch, torch.nn as nn
-class GInformer(nn.Module):
-    def __init__(self, d_model=768, nhead=8, num_layers=1):
+import math
+
+
+def prob_sparse_attention(q, k, v, u):
+    # q:(B,Lq,D), k,v:(B,Lk,D)
+    B, Lq, D = q.shape
+    Lk = k.size(1)
+    scores = torch.zeros(B, Lq, Lk, device=q.device)
+    idx = torch.randint(0, Lk, (Lq, u), device=q.device)
+    for i in range(Lq):
+        qi = q[:, i:i+1, :]
+        ki = k.gather(1, idx[i].expand(B, u).unsqueeze(-1).repeat(1, 1, D))
+        tmp = (qi @ ki.transpose(-2, -1) / math.sqrt(D)).squeeze(-2)
+        mm = tmp.max(-1).values - tmp.mean(-1)
+        scores[:, i, idx[i]] = mm.unsqueeze(-1)
+    attn = torch.softmax(scores, dim=-1)
+    return attn @ v
+
+
+class InformerBlock(nn.Module):
+    def __init__(self, d_model=768, nhead=8):
         super().__init__()
-        self.enc = nn.TransformerEncoder(
-            nn.TransformerEncoderLayer(d_model, nhead, batch_first=True),
-            num_layers=num_layers)
-    def forward(self, x):           # x: (B,T,D) 全履歴
-        return self.enc(x)[:,-1]
+        self.proj_q = nn.Linear(d_model, d_model)
+        self.proj_k = nn.Linear(d_model, d_model)
+        self.proj_v = nn.Linear(d_model, d_model)
+        self.ff = nn.Sequential(
+            nn.Linear(d_model, 4 * d_model), nn.GELU(), nn.Linear(4 * d_model, d_model))
+        self.norm1 = nn.LayerNorm(d_model)
+        self.norm2 = nn.LayerNorm(d_model)
+
+    def forward(self, x):
+        q = self.proj_q(x)
+        k = self.proj_k(x)
+        v = self.proj_v(x)
+        u = int(k.size(1) * math.log(q.size(1)))  # U = Lk ln Lq
+        z = prob_sparse_attention(q, k, v, u)
+        x = self.norm1(x + z)
+        x = self.norm2(x + self.ff(x))
+        return x
+
+
+class GInformer(nn.Module):
+    def __init__(self, layers=2, d_model=768):
+        super().__init__()
+        self.blocks = nn.ModuleList([InformerBlock(d_model) for _ in range(layers)])
+
+    def forward(self, seq):               # seq (B,T,D) 全履歴
+        x = seq
+        for blk in self.blocks:
+            x = blk(x)
+        return x[:, -1]                    # g_t

--- a/content/LoViT_APTOS/head.py
+++ b/content/LoViT_APTOS/head.py
@@ -1,8 +1,18 @@
-import torch, torch.nn as nn
+import torch
+import torch.nn as nn
+
+
 class FusionHead(nn.Module):
-    def __init__(self, d_model=768, n_classes=35):
+    def __init__(self, d_model=768, n_cls=35):
         super().__init__()
-        self.fc = nn.Linear(d_model*3, n_classes)
-    def forward(self, s,l,g):
-        z = torch.cat([s,l,g], dim=-1)
-        return self.fc(z)
+        self.fuse1 = nn.TransformerEncoder(
+            nn.TransformerEncoderLayer(d_model * 2, 8, batch_first=True), 2)
+        self.fuse2 = nn.TransformerEncoder(
+            nn.TransformerEncoderLayer(d_model * 3, 8, batch_first=True), 1)
+        self.phase_cls = nn.Linear(d_model * 3, n_cls)
+        self.ht_map = nn.Linear(d_model * 3, 1)      # scalar heat値
+
+    def forward(self, s, l, g):
+        flocal = self.fuse1((torch.cat([s, l], dim=-1)).unsqueeze(1)).squeeze(1)
+        fglob = self.fuse2((torch.cat([flocal, g], dim=-1)).unsqueeze(1)).squeeze(1)
+        return self.phase_cls(fglob), self.ht_map(fglob).squeeze(-1)

--- a/content/LoViT_APTOS/infer.py
+++ b/content/LoViT_APTOS/infer.py
@@ -20,7 +20,7 @@ for vname, g in pd.read_csv(CSV_VAL).groupby('Video_name'):
     for _, r in g.sort_values('Frame_id').iterrows():
         img = Image.open(os.path.join(FRAME_ROOT, r.Frame_id))
         clip = tf(img).unsqueeze(0).unsqueeze(0).cuda()   # shape (1,1,3,H,W)
-        pred = lovit(clip).argmax(-1).item()
+        pred = lovit(clip)[0].argmax(-1).item()
         rows.append(pred)
 out = pd.read_csv(CSV_VAL).copy()
 out['Predict_phase_id'] = rows

--- a/content/LoViT_APTOS/ltrans.py
+++ b/content/LoViT_APTOS/ltrans.py
@@ -1,13 +1,40 @@
 import torch, torch.nn as nn
 from einops import rearrange
 
-class LTrans(nn.Module):
-    def __init__(self, d_model=768, nhead=8, num_layers=2, win=64):
+class FusionModule(nn.Module):
+    """Encoder (m×SelfAtt) + Decoder (n×{Self+Cross})"""
+    def __init__(self, d_model, nhead, m=2, n=2):
         super().__init__()
-        self.win = win
         self.enc = nn.TransformerEncoder(
-            nn.TransformerEncoderLayer(d_model, nhead, batch_first=True),
-            num_layers=num_layers)
-    def forward(self, x):           # x: (B,T,D)
-        x = x[:, -self.win:]
-        return self.enc(x)[:,-1]    # (B,D)
+            nn.TransformerEncoderLayer(d_model, nhead, batch_first=True), m)
+        self.dec_layers = nn.ModuleList(
+            [nn.TransformerDecoderLayer(d_model, nhead, batch_first=True)
+             for _ in range(n)])
+
+    def forward(self, aux_feat, main_feat):
+        # aux_feat, main_feat: (B,T,D)
+        memory = self.enc(aux_feat)
+        out = main_feat
+        for dec in self.dec_layers:
+            out = dec(out, memory)
+        return out
+
+class CascadedLTrans(nn.Module):
+    """
+    Two-scale L_s(L=λ1) & L_l(L=λ2) as in Fig 4.
+    巻き戻し勉強節縛の detach() ロジックも含む。
+    """
+    def __init__(self, d_model=768, nhead=8, lambda1=100, lambda2=500):
+        super().__init__()
+        self.lambda1, self.lambda2 = lambda1, lambda2
+        self.fusion_s = FusionModule(d_model, nhead)
+        self.fusion_l = FusionModule(d_model, nhead)
+
+    def forward(self, seq):               # (B,T,D)
+        # --- Small window branch ---
+        s_in = seq[:, -self.lambda1:].detach()
+        s_out = self.fusion_s(s_in, s_in)
+        # --- Large window branch (takes small-scale output as aux) ---
+        l_in = seq[:, -self.lambda2:].detach()
+        l_out = self.fusion_l(s_out.detach(), l_in)
+        return s_out[:,-1], l_out[:,-1]   # 最後の token を代表に

--- a/content/LoViT_APTOS/train_lovit.py
+++ b/content/LoViT_APTOS/train_lovit.py
@@ -1,0 +1,30 @@
+import torch
+import torch.nn as nn
+import torch.optim as optim
+from datasets import PhaseVideoDataset, DataLoader
+from model import LoViT
+
+ALPHA = 8
+BS = 4
+
+train_ds = PhaseVideoDataset(
+    '/content/drive/MyDrive/kaggle/APTOS/APTOS_train-val_annotation.csv',
+    '/content/drive/MyDrive/kaggle/APTOS/aptos_videos',
+    '/content/drive/MyDrive/kaggle/APTOS/meta/video_fps.csv',
+    split='train',
+    video_subset=['case_0985','case_0791','case_1362','case_1475','case_1944','case_0690','case_0612'],
+    alpha=ALPHA)
+
+loader = DataLoader(train_ds, BS, shuffle=True, num_workers=2)
+
+lovit = LoViT()
+lovit.freeze_extractor()
+opt = optim.SGD(filter(lambda p: p.requires_grad, lovit.parameters()), lr=3e-4, momentum=0.9)
+L1 = nn.L1Loss(); CE = nn.CrossEntropyLoss()
+
+for clip, pid, ht_gt in loader:
+    opt.zero_grad()
+    pred_p, pred_h = lovit(clip)
+    loss = CE(pred_p, pid) + L1(pred_h, ht_gt)
+    loss.backward()
+    opt.step()


### PR DESCRIPTION
## Summary
- add phase transition heatmap generation
- replace L-Trans with cascaded version
- implement ProbSparse Informer attention
- extend fusion head for phase and heat outputs
- modify model forward to output `(p_t, h_t)`
- adapt inference script for new output
- provide simple training example using combined loss

## Testing
- `python -m py_compile content/LoViT_APTOS/*.py`

------
https://chatgpt.com/codex/tasks/task_e_684bf02ff6008331a884de90640337ad